### PR TITLE
install: Install Quilt binaries through npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+This repo contains a Node.js package for easily installing
+[Quilt](http://quilt.io) using npm.
+
+To pull the compiled binaries off GitHub, and install them:
+```
+$ npm install quilt/install
+```

--- a/install.js
+++ b/install.js
@@ -1,0 +1,47 @@
+const version = require("./package.json").version;
+const os = require('os');
+const fs = require('fs');
+const https = require('https');
+
+function main() {
+  const platform = os.platform();
+  switch(platform) {
+    case 'darwin':
+    case 'linux':
+      break;
+    default:
+      throw `Unrecognized operating system ${platform}. Bailing.`
+  }
+
+  const url = `https://github.com/quilt/quilt/releases/download/${version}` +
+        `/quilt_${platform}`;
+  https.get(url, writeFile).on('error', logError('HTTP GET'));
+}
+
+function writeFile(resp) {
+  if (resp.statusCode >= 400) {
+    throw 'Binary not found. Please contact Quilt at dev@quilt.io.'
+  }
+
+  // Follow redirects.
+  if (resp.headers['location']) {
+    https.get(resp.headers['location'], writeFile).
+      on('error', logError('HTTP GET'));
+    return
+  }
+
+  var outFile = fs.createWriteStream('quilt');
+  resp.pipe(outFile).on('error', logError('Write file'));
+  outFile.on('finish', function() {
+    outFile.close();
+  });
+}
+
+function logError(description) {
+  return function(err) {
+    console.log(description + ": " + err);
+    process.exit(1);
+  }
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@quilt/install",
+  "version": "0.1.0",
+  "homepage": "http://quilt.io",
+  "license": "MIT",
+  "preferGlobal": true,
+  "scripts": {
+    "preinstall": "node install.js"
+  },
+  "bin": {
+    "quilt": "quilt"
+  }
+}


### PR DESCRIPTION
This patch allows users to install Quilt binaries by running `npm
install quilt/install`.