### PR TITLE
readme: Fix example invocation to install globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,7 @@ This repo contains a Node.js package for easily installing
 
 To pull the compiled binaries off GitHub, and install them:
 ```
-$ npm install quilt/install
+$ npm install -g quilt/install
 ```
+Note that the `-g` flag is necessary to install the binaries globally (i.e. so
+that `quilt` can be invoked from anywhere).


### PR DESCRIPTION
If we don't install globally, the package will simply be installed into
the `node_modules` subdirectory.