### PR TITLE
readme: Install from npm repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This repo contains a Node.js package for easily installing
 
 To pull the compiled binaries off GitHub, and install them:
 ```
-$ npm install -g quilt/install
+$ npm install -g @quilt/install
 ```
 Note that the `-g` flag is necessary to install the binaries globally (i.e. so
 that `quilt` can be invoked from anywhere).


### PR DESCRIPTION
Now that the package is hosted on npmjs.com, users should install
directly from NPM rather than through GitHub.